### PR TITLE
В плагин добавлен http клиент и замена текста в редакторе.

### DIFF
--- a/src/java/buddyplugin/build.gradle
+++ b/src/java/buddyplugin/build.gradle
@@ -2,6 +2,9 @@ plugins {
     id 'org.jetbrains.intellij' version '0.4.21'
 }
 
+sourceCompatibility = JavaVersion.VERSION_11
+targetCompatibility = JavaVersion.VERSION_11
+
 group 'com.evdokimoval.plugin'
 version '1.0-SNAPSHOT'
 

--- a/src/java/buddyplugin/src/main/java/BuddyAction.java
+++ b/src/java/buddyplugin/src/main/java/BuddyAction.java
@@ -1,16 +1,68 @@
-
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
-import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.actionSystem.CommonDataKeys;
+import com.intellij.openapi.actionSystem.PlatformDataKeys;
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Caret;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import java.io.IOException;
 
 public class BuddyAction extends AnAction {
     @Override
     public void actionPerformed(AnActionEvent event) {
-        Messages.showMessageDialog("Test Action", "BuddyAction", Messages.getInformationIcon());
+        Editor editor = event.getData(PlatformDataKeys.EDITOR);
+        String selectedCode = editor.getSelectionModel().getSelectedText();
+        HttpResponse<String> result = null;
+        try {
+            result = sendPostWithJsonBody("http://127.0.0.1:8000/predictor/predict", selectedCode);
+        } catch (IOException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        Project project = event.getRequiredData(CommonDataKeys.PROJECT);
+        Document document = editor.getDocument();
+        Caret primaryCaret = editor.getCaretModel().getPrimaryCaret();
+        int start = primaryCaret.getSelectionStart();
+        int end = primaryCaret.getSelectionEnd();
+
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode nameNode = null;
+        try {
+            nameNode = mapper.readTree(result.body());
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+
+        JsonNode finalNameNode = nameNode;
+        WriteCommandAction.runWriteCommandAction(project, () ->
+                document.replaceString(start, end, finalNameNode.get("result").asText())
+        );
+        primaryCaret.removeSelection();
     }
 
     @Override
     public boolean isDumbAware() {
         return false;
+    }
+
+
+    public static HttpResponse<String> sendPostWithJsonBody(String serviceUrl, String selectedCode) throws IOException, InterruptedException {
+        HttpClient client = HttpClient.newHttpClient();
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(serviceUrl))
+                .POST(HttpRequest.BodyPublishers.ofString(String.format("{\"code\":\"%s\"}", selectedCode)))
+                .build();
+        return client.send(request, HttpResponse.BodyHandlers.ofString());
     }
 }

--- a/src/java/buddyplugin/src/main/resources/META-INF/plugin.xml
+++ b/src/java/buddyplugin/src/main/resources/META-INF/plugin.xml
@@ -1,6 +1,6 @@
 <idea-plugin>
     <id>com.evdokimoval.plugin</id>
-    <name>Plugin display name here</name>
+    <name>Buddy plugin</name>
     <vendor email="artem_evdokimov_1992@mail.ru">evdokimoval</vendor>
 
     <description><![CDATA[


### PR DESCRIPTION
Рабочая версия плагина, зацепляется к модели по адресу http://127.0.0.1:8000/predictor/predict
после сборки плагина (инструкция приложена к проекту) необходимо установить плагин
по дефолту он собирается по пути src\java\buddyplugin\build\distributions
для вызова плагина используем команду ctr \ + t